### PR TITLE
fix: Broken markdown in code snippets

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+[*]
+insert_final_newline=true
+indent_style=space
+indent_size=2
+
+[{*.html, *.hbs}]
+indent_size=4
+

--- a/builder/layouts/index.hbs
+++ b/builder/layouts/index.hbs
@@ -9,7 +9,8 @@
       <h2 class="group">{{capitalize value}} snippets</h2>
 
       {{#each items}}
-        {{>snippet}}
+{{!-- don't indent, it'll break code examples --}}
+{{>snippet}}
       {{/each}}
     </section>
   {{/group}}

--- a/builder/layouts/snippet.hbs
+++ b/builder/layouts/snippet.hbs
@@ -21,7 +21,8 @@
 
 {{#> full-body }}
 
-    {{>snippet}}
+{{!-- don't indent, it'll break code examples --}}
+{{>snippet}}
 
     {{#if (hasCode this)}}
         <div class="mdl-card mdl-shadow--2dp card demo-card">

--- a/builder/partials/body.hbs
+++ b/builder/partials/body.hbs
@@ -1,13 +1,14 @@
 {{!-- see head.hbs for start --}}
 
+{{!-- don't indent, it'll break code examples --}}
 {{#if class }}
-  <body class="{{ class }}">
-  {{> @partial-block }}
-  </body>
+<body class="{{ class }}">
+{{> @partial-block }}
+</body>
 {{ else }}
-  <body>
-  {{> @partial-block }}
-  </body>
+<body>
+{{> @partial-block }}
+</body>
 {{/if}}
 
 </html>

--- a/builder/partials/full-body.hbs
+++ b/builder/partials/full-body.hbs
@@ -1,7 +1,8 @@
 {{#> body }}
   {{> header }}
 
-  {{> @partial-block }}
+{{!-- don't indent, it'll break code examples --}}
+{{> @partial-block }}
 
   {{> footer }}
 {{/body}}

--- a/builder/partials/snippet.hbs
+++ b/builder/partials/snippet.hbs
@@ -35,7 +35,7 @@
     </span>
             {{/each}}
         </div>
-        
+
         <div class="author">
             {{#if this.author}}
                 <a class="github-button"

--- a/snippets/mark-reactive-fields-as-touched.md
+++ b/snippets/mark-reactive-fields-as-touched.md
@@ -16,12 +16,12 @@ Here is the way to notify user that there are fields with non-valid values.
 `markFieldsAsTouched` function FormGroup or FormArray as an argument. 
 
 ```typescript
-  function markFieldsAsTouched(form: AbstractControl): void {
-    form.markAsTouched({ onlySelf: true });
-    if (form instanceof FormArray || form instanceof FormGroup) {
-      Object.values(form.controls).forEach(markFieldsAsTouched);
-    }
+function markFieldsAsTouched(form: AbstractControl): void {
+  form.markAsTouched({ onlySelf: true });
+  if (form instanceof FormArray || form instanceof FormGroup) {
+    Object.values(form.controls).forEach(markFieldsAsTouched);
   }
+}
 ```
 
 # ComponentCode

--- a/snippets/safe-navigation-operator.md
+++ b/snippets/safe-navigation-operator.md
@@ -1,7 +1,7 @@
 ---
 title: Safe Navigation Operator
 level: beginner
-author: alex_bu
+author: alex-bu-93
 tags:
   - object property handling
   - tips


### PR DESCRIPTION
Fixes indentation problem with code samples
![7a318911-de9f-4d56-9e5e-bcc286153d7a](https://user-images.githubusercontent.com/577042/59561924-08a99800-9026-11e9-9edb-ddb687babbe7.jpg)


Also closes #158 